### PR TITLE
Nk/testing 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ cache: pip
 install:
   - pip install -r requirements.txt
 script:
+  - . .env
   - python -m pytest

--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ app.config.from_object(os.environ['APP_SETTINGS'])
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db = SQLAlchemy(app)
 
-# import models
+import models
 
 @app.route('/')
 def hello():

--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ app.config.from_object(os.environ['APP_SETTINGS'])
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db = SQLAlchemy(app)
 
-import models
+# import models
 
 @app.route('/')
 def hello():

--- a/tests/test_campsite.py
+++ b/tests/test_campsite.py
@@ -4,3 +4,26 @@ import tempfile
 import pytest
 
 from models import Campsite
+
+campsite = Campsite(
+        image_url = 'www.example.com',
+        city = 'Fruita',
+        state = 'CO',
+        name = '18 Road',
+        description = 'Awesome',
+        driving_tips = 'Turn Left, then right',
+        lon = 18.4,
+        lat = 17.2,
+        datetime = 124
+        )
+
+def test_attributes():
+    assert campsite.name == '18 Road'
+    assert campsite.image_url == 'www.example.com'
+    assert campsite.city == 'Fruita'
+    assert campsite.state == 'CO'
+    assert campsite.description == 'Awesome'
+    assert campsite.driving_tips == 'Turn Left, then right'
+    assert campsite.lon == 18.4
+    assert campsite.lat == 17.2
+    assert campsite.datetime == 124

--- a/tests/test_campsite.py
+++ b/tests/test_campsite.py
@@ -1,0 +1,6 @@
+import os
+import tempfile
+
+import pytest
+
+from models import Campsite

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,5 +1,0 @@
-# content of test_sample.py
-def func(x):
-    return x + 1
-def test_answer():
-    assert func(3) == 4

--- a/venv/pyvenv.cfg
+++ b/venv/pyvenv.cfg
@@ -1,0 +1,3 @@
+home = /usr/local/bin
+include-system-site-packages = false
+version = 3.7.7


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling/UX

### Detailed Description
Test for the campsite model. Included in the PR.
To 'pry' into a test with pytest use the command:

pytest.set_trace()

This will give you an interactive pry session. Not as nice as pry but it works fine (all in was testing were that attributes exist on an instance of a campsite). 

Implemented the coverage.py package.
https://coverage.readthedocs.io/en/coverage-5.1/

You will need to:
      pip install coverage

To run the coverage report:
    coverage run -m pytest
    coverage report

See doc link above for more detail.

### Closes Issue
#18 

### Why is this change required? What problem does it solve?
We can now test!

### Were there any challenges that arose while implementing this feature? If so, how were they resolved?
The test example for the flask framework wasn;t working. Maybe we can pair on this issue. For now, we can test models.

Coverage is starting at a base of 35% but the models are at 100%. The rest are packages we have included in our app.

### Test coverage snapshot:

TOTAL                                                                                               66933  43261    35%
