### PR TITLE
Bug in comments where rating was over ridden by description

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,7 +19,7 @@ def create_app(config_name):
 	app.config.from_pyfile('config.py')
 	app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 	db.init_app(app)
-	
+
 
 	@app.route('/campsites/<int:id>', methods=['GET', 'PUT', 'DELETE'])
 	def campsite_manipulation(id, **kwargs):
@@ -168,7 +168,7 @@ def create_app(config_name):
 					'id': comment.id,
 					'title': comment.title,
 					'description': comment.description,
-					'rating': comment.description
+					'rating': comment.rating
 				}
 				results.append(obj)
 			response = jsonify(results)

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@ from flask_script import Manager
 from flask_migrate import Migrate, MigrateCommand
 from app import db, create_app
 from app import models
-from app.models import Amenity, Campsite
+from app.models import Amenity, Campsite, Comment
 
 app = create_app(config_name=os.getenv('APP_SETTINGS'))
 migrate = Migrate(app, db)
@@ -25,7 +25,7 @@ def seed():
         name = '18 Rd-North Fruita Desert',
         description = 'Biking galore',
         city = 'Fruita',
-        image_url = 'https://www.google.com/url?sa=i&url=https%3A%2F%2Fwww.gofruita.com%2Fthingstodo%2Ffruita-mountain-biking&psig=AOvVaw2cnhfhm603aBdCDphoIgrp&ust=1590849990405000&source=images&cd=vfe&ved=0CAIQjRxqFwoTCOCA1pao2ekCFQAAAAAdAAAAABAF',
+        image_url = 'https://cdn-files.apstatic.com/mtb/285374_medium_1554167980.jpg',
         state = 'CO',
         driving_tips = 'Take Interstate 70 west to Fruita (exit 19). Turn north onto Cherry Street and take the first right onto Aspen Avenue. Go through the roundabout and continue on Aspen to Maple Street. Take a left on Maple Street and then travel north. The street will turn into 17.5 road. Take a right on N.3 Road and then a left on 18 Road. Travel approximately 7 miles on 18 Road to the trailhead. Camping is allowed in designated campsites; A firepan and a portable toilet are required outside of the developed campground. Camping in designated sites costs $10.00/night. If you go just a little North these is free campings with limited amenities',
         lon = -108.704,
@@ -34,6 +34,10 @@ def seed():
     campsite1.amenities.append(fire)
     campsite1.amenities.append(hike)
     campsite1.amenities.append(bike)
+    comment1 = Comment(title = 'Best Biking in Western Colorado', description = 'It gets hot during the day but the campsites are right off the trail so you can go back to camp and cool off.', rating = "5")
+    comment2 = Comment(title = 'Scorpians!', description = 'I did not know scorpians swarmed. At our camp they do...', rating = "3")
+    campsite1.comments.append(comment1)
+    campsite1.comments.append(comment2)
 
     campsite2 = Campsite(
         name = 'McInnis Canyons Nation Conservation Area',
@@ -47,6 +51,10 @@ def seed():
         )
     campsite2.amenities.append(fire)
     campsite2.amenities.append(hike)
+    comment3 = Comment(title = 'The Views!', description = 'The dispersed camping has eveything you need.', rating = "5")
+    comment4 = Comment(title = 'The camping areas flood.', description = 'Do not go if there is rain in forecast.', rating = "5")
+    campsite2.comments.append(comment3)
+    campsite2.comments.append(comment4)
 
     campsite3 = Campsite(
         name = 'North Fruita Desert',
@@ -56,7 +64,7 @@ def seed():
         state = 'CO',
         driving_tips = 'Take Interstate 70 west to Fruita (exit 19). Turn north onto Cherry Street and take the first right onto Aspen Avenue. Go through the roundabout and continue on Aspen to Maple Street. Take a left on Maple Street and then travel north. The street will turn into 17.5 road. Take a right on N.3 Road and then a left on 18 Road. Travel approximately 7 miles on 18 Road to the campground.',
         lon = -108.704,
-        lat = 39.334
+        lat = 39.400
         )
     campsite3.amenities.append(fire)
     campsite3.amenities.append(hike)
@@ -66,7 +74,7 @@ def seed():
         name = 'Knowles Overlook',
         description = '7 Undevolped Sites. High clearance vehicle required to enter. Pit toliet.',
         city = 'Grand Junction',
-        image_url = 'https://www.tripsavvy.com/thmb/7NDLY4l9IqOVrDivKfIb6uz5eu0=/2048x1366/filters:fill(auto,1)/mcinniscanyons-5c51e8ecc9e77c00016f38ed.jpg',
+        image_url = 'https://live.staticflickr.com/790/39454032510_5b66ff4702_b.jpg',
         state = 'CO',
         driving_tips = 'From Grand Junction travel west on I-70 and take exit 2 towards Rabbit Valley. Take a left over the interstate and travel straight into McInnis Canyons National Conservation Area. Take a right at the first intersection and a left at the second intersection. Stay on the main road for approximately 2.8 miles and take a left. The campground is approximately 1.3 miles further.',
         lon = -109.03,
@@ -79,7 +87,7 @@ def seed():
         name = 'Rabbit Valley',
         description = 'Great for motorcyles and ATVs. Dispersed camping only allowe at designated sites.',
         city = 'Grand Junction',
-        image_url = 'https://lh3.googleusercontent.com/proxy/KY1mqBdxe3Wg_lLR9g-caX-iv9NTteDDCla0EiQ_1jSVaxbdo0iRP8fM9zTnV2xLRaZcLCYBAHvHWsOL-zXVLEALYKHnQzKTTimwYPcd0yf2OqArWrNFEN1s-NpwxhiuKg',
+        image_url = 'https://www.riderplanet-usa.com/atv/trails/photo/370/50cc7275ac384baf8fd8077acab53e3e.jpg',
         state = 'CO',
         driving_tips = 'From Grand Junction travel west on Hwy 70 and take exit 2. Take a left over the Interstate and go straight into the McInnis Canyons National Conservation Area.',
         lon = -109.02,
@@ -91,10 +99,10 @@ def seed():
     campsite5.amenities.append(atv)
 
     campsite6 = Campsite(
-        name = 'Kokopelli;s Trail',
+        name = 'Kokopellis Trail',
         description = 'Camping in designated spots only. 9 Small camping areas. Most campgrounds are free.',
         city = 'Moab',
-        image_url = '',
+        image_url = 'https://images.singletracks.com/blog/wp-content/uploads/2017/02/image46202-1200x900.jpg',
         state = 'UT',
         driving_tips = 'From Grand Junction, travel west on Interstate 70 about 15 miles. Take the Loma exit (exit 15), then travel west on gravel frontage road south of the interstate. The trailhead is on the left. Look for signs. Contact the Moab or Grand Junction Field Office for more information.',
         lon = -108.82744,
@@ -117,6 +125,10 @@ def seed():
     db.session.add(campsite4)
     db.session.add(campsite5)
     db.session.add(campsite6)
+    db.session.add(comment1)
+    db.session.add(comment2)
+    db.session.add(comment3)
+    db.session.add(comment4)
     db.session.commit()
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Type of change made:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling/UX

### Detailed Description
When a get request was being returned there was an issue where the rating was being overridden by the description. Bug traced and corrected.

Alongside this bug change am pushing up campsite1 and campsite2 to include comments in the seed file.

### Why is this change required? What problem does it solve?
Bug. Broken Code.

### Were there any challenges that arose while implementing this feature? If so, how were they resolved?
N/a

### Test coverage snapshot:
N/A