### PR TITLE
CoverageRC implementation 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = /usr/local/lib/python3.7/*

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -119,6 +119,7 @@ def create_app(config_name):
 			results = []
 
 			for campsite in campsites:
+				avg_rating = { 'average_rating': campsite.average_rating() }
 				obj = {
 						'id': campsite.id,
 						'name': campsite.name,
@@ -133,9 +134,10 @@ def create_app(config_name):
 						'amenities': str(campsite.list_amenities())
 						}
 				results.append(obj)
+				results.append(avg_rating)
 			response = jsonify(results)
 			response.status_code = 200
-			return response
+		return response
 
 	@app.route('/campsites/<int:id>/comments', methods=['GET', 'POST'])
 	def comments(id, **kwargs):
@@ -162,7 +164,7 @@ def create_app(config_name):
 
 		else:
 			comments = campsite.comments
-			avg_rating = { 'average_rating': campsite.average_rating(comments) }
+			avg_rating = { 'average_rating': campsite.average_rating() }
 			results = []
 			for comment in comments:
 				obj = {

--- a/app/models.py
+++ b/app/models.py
@@ -51,12 +51,12 @@ class Campsite(db.Model):
             collect.append(amenity.name)
         return collect
 
-    def average_rating(self, comments):
+    def average_rating(self):
         all_comments = []
         comments = self.comments
         if not comments:
-            total = 0
-        
+            total = 'no comments'
+
         for comment in comments:
             all_comments.append(int(comment.rating))
             total = sum(all_comments) / len(all_comments)

--- a/test_campsite.py
+++ b/test_campsite.py
@@ -106,7 +106,7 @@ class CampsiteTestCase(unittest.TestCase):
         res = self.client().delete('/campsites/1/comments/1')
         self.assertEqual(res.status_code, 200)
         result = self.client().get('/campsites/1/comments')
-        self.assertEqual(result.data, b'[\n  [], \n  {\n    "average_rating": 0\n  }\n]\n')
+        self.assertEqual(result.data, b'[\n  [], \n  {\n    "average_rating": "no comments"\n  }\n]\n')
 
     def tearDown(self):
         """teardown all initialized variables."""

--- a/test_models.py
+++ b/test_models.py
@@ -72,7 +72,7 @@ class ModelTestCase(unittest.TestCase):
         comment2 = Comment(title = 'Scorpians!', description = 'I did not know scorpians swarmed. At our camp they do...', rating = "3")
         campsite1.comments.append(comment1)
         campsite1.comments.append(comment2)
-        self.assertEqual(campsite1.average_rating(campsite1.comments), 4)
+        self.assertEqual(campsite1.average_rating(), 4)
 
     def test_list_amenities(self):
         campsite1 = Campsite(


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling/UX

### Detailed Description
Create .coveragerc file to ignore python/flask packages in cov report.

Also added the average rating of a campsite to come through with a GET /campsites/ request.
Adjust average rating to return 'no comments' instead of 0 when there is n0 rating.

Commands to run:
$ coverage run -m unittest
THEN
$ coverage report

### Why is this change required? What problem does it solve?
Lets us ignore package files for testing.

### Were there any challenges that arose while implementing this feature? If so, how were they resolved?
coverage.py docs were hard to navigate.

### Test coverage snapshot:
2:47
Name                 Stmts   Miss  Cover
----------------------------------------
app/__init__.py        103      2    98%
app/models.py           88      5    94%
instance/config.py      18      0   100%
test_campsite.py        83      1    99%
test_models.py          51      1    98%
----------------------------------------
TOTAL                  343      9    97%