### PR TITLE
revise avg rating on response

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -119,7 +119,6 @@ def create_app(config_name):
 			results = []
 
 			for campsite in campsites:
-				avg_rating = { 'average_rating': campsite.average_rating() }
 				obj = {
 						'id': campsite.id,
 						'name': campsite.name,
@@ -131,10 +130,10 @@ def create_app(config_name):
 						'lon': campsite.lon,
 						'lat': campsite.lat,
 						'timestamp': campsite.date_created,
-						'amenities': str(campsite.list_amenities())
+						'amenities': str(campsite.list_amenities()),
+						'average_rating': campsite.average_rating()
 						}
 				results.append(obj)
-				results.append(avg_rating)
 			response = jsonify(results)
 			response.status_code = 200
 		return response


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Change

### Detailed Description
Change response to include the average rating of a campsite in the obj sent to FE instead of having it as a separate hash.

### Why is this change required? What problem does it solve?
Makes things easier to handle on FE

