### PR TITLE
Get all campsites now returns all campsites instead one last campsite.

### DIFF
--- a/app/controllers/campsite_controller.py
+++ b/app/controllers/campsite_controller.py
@@ -57,7 +57,7 @@ class CampsiteController:
 			results.append(obj)
 			response = jsonify(results)
 			response.status_code = 200
-			return response
+		return response
 
 	def update(self, campsite):
 		name = str(request.data.get('name', campsite.name))
@@ -110,4 +110,3 @@ class CampsiteController:
 		})
 		response.status_code = 200
 		return response
-


### PR DESCRIPTION
### Type of change made:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling/UX

### Detailed Description
GET /campsites/ was only returning the last campsite. it now returns all campsites as intended

### Why is this change required? What problem does it solve?
BUG. Only one campsite was being returned for a GET all.

### Were there any challenges that arose while implementing this feature? If so, how were they resolved?

No

### Test coverage snapshot:
app/__init__.py                             48      2    96%
app/controllers/campsite_controller.py      58      0   100%
app/controllers/comments_controller.py      26      0   100%
app/models.py                               88      5    94%
instance/config.py                          18      0   100%
test_campsite.py                            83      1    99%
test_models.py                              51      1    98%
------------------------------------------------------------
TOTAL                                      372      9    98%