### PR TITLE
Testing Refactor-Add sad path testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ install:
   - pip install -r requirements.txt
 before_script: psql -c "CREATE DATABASE test_db;" -U postgres
 script:
-  - . .env
+  - source .env
   - python -m unittest

--- a/manage.py
+++ b/manage.py
@@ -35,7 +35,7 @@ def seed():
     campsite1.amenities.append(hike)
     campsite1.amenities.append(bike)
     comment1 = Comment(title = 'Best Biking in Western Colorado', description = 'It gets hot during the day but the campsites are right off the trail so you can go back to camp and cool off.', rating = "5")
-    comment2 = Comment(title = 'Scorpians!', description = 'I did not know scorpians swarmed. At our camp they do...', rating = "3")
+    comment2 = Comment(title = 'Scorpions!', description = 'I did not know scorpions swarmed. At our camp they do...', rating = "3")
     campsite1.comments.append(comment1)
     campsite1.comments.append(comment2)
 

--- a/test_models.py
+++ b/test_models.py
@@ -83,7 +83,7 @@ class ModelTestCase(unittest.TestCase):
             lon = -108.704,
             lat = 39.334
             )
-        import pdb; pdb.set_trace()
+
         self.assertEqual(campsite1.average_rating(), 'no comments')
 
     def test_list_amenities(self):

--- a/test_models.py
+++ b/test_models.py
@@ -55,8 +55,6 @@ class ModelTestCase(unittest.TestCase):
         self.assertEqual(campsite.comments, [comment1, comment2])
         self.assertEqual(campsite.amenities, [fire, hike])
 
-
-
     def test_average_rating(self):
         campsite1 = Campsite(
             name = '18 Rd-North Fruita Desert',
@@ -73,6 +71,20 @@ class ModelTestCase(unittest.TestCase):
         campsite1.comments.append(comment1)
         campsite1.comments.append(comment2)
         self.assertEqual(campsite1.average_rating(), 4)
+
+    def test_average_rating_no_comments(self):
+        campsite1 = Campsite(
+            name = '18 Rd-North Fruita Desert',
+            description = 'Biking galore',
+            city = 'Fruita',
+            image_url = 'https://cdn-files.apstatic.com/mtb/285374_medium_1554167980.jpg',
+            state = 'CO',
+            driving_tips = 'Take Interstate 70 west to Fruita (exit 19). Turn north onto Cherry Street and take the first right onto Aspen Avenue. Go through the roundabout and continue on Aspen to Maple Street. Take a left on Maple Street and then travel north. The street will turn into 17.5 road. Take a right on N.3 Road and then a left on 18 Road. Travel approximately 7 miles on 18 Road to the trailhead. Camping is allowed in designated campsites; A firepan and a portable toilet are required outside of the developed campground. Camping in designated sites costs $10.00/night. If you go just a little North these is free campings with limited amenities',
+            lon = -108.704,
+            lat = 39.334
+            )
+        import pdb; pdb.set_trace()
+        self.assertEqual(campsite1.average_rating(), 'no comments')
 
     def test_list_amenities(self):
         campsite1 = Campsite(


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Testing Enhancement

### Detailed Description
Add sad path testing for average_rating method.

### Why is this change required? What problem does it solve?
Adds a catch if there are not ratings for a campsite.

### Were there any challenges that arose while implementing this feature? If so, how were they resolved?
No

### Test coverage snap shot:

Name                                     Stmts   Miss  Cover
------------------------------------------------------------
app/__init__.py                             48      2    96%
app/controllers/campsite_controller.py      58      0   100%
app/controllers/comments_controller.py      26      0   100%
app/models.py                               88      5    94%
instance/config.py                          18      0   100%
test_campsite.py                            83      1    99%
test_models.py                              51      1    98%
------------------------------------------------------------
TOTAL                                      372      9    98%

